### PR TITLE
Portfolio: preserve data in the browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 <!-- Modal Settings Starts -->
 <section id="modalSetting" class="modalContainer">
   <div id="modalContentSetting" class="modalContent">
-    <button id="btnCloseNav" class="btn-icon">
+    <button type="button" id="btnCloseNav" class="btn-icon">
       <img src="images/modalPopup/cross.png" alt="">
     </button>
     <div>
@@ -293,7 +293,7 @@ don’t hesitate to contact me.
   </h1>
   <form action="https://formspree.io/f/xoqzrdep" method="post" class="contact-form" id="form_contact">
     <div class="form-elements">
-      <input type="text" maxlength="30" placeholder="Full name" class="form-input" name="fullname" required>
+      <input type="text" id="txtFullname" maxlength="30" placeholder="Full name" class="form-input" name="fullname" required>
       <input type="email" id="txtEmail" placeholder="Email address" class="form-input" name="email" required>
       <small></small>
       <textarea name="txt_message" id="txt_message" cols="30" rows="5" maxlength="500" placeholder="Write me something..." class="form-input form-textarea" required></textarea>

--- a/index.html
+++ b/index.html
@@ -336,5 +336,6 @@ don’t hesitate to contact me.
 <!-- Modal Project Starts -->
   
   <script src="script.js"></script>
+  <script src="storedata.js"></script>
 </body>
 </html>

--- a/storedata.js
+++ b/storedata.js
@@ -1,3 +1,4 @@
+// Create form data object
 const formData = {};
 
 const fullName = document.getElementById('txtFullname');
@@ -7,3 +8,6 @@ const textMessage = document.getElementById('txt_message');
 formData.name = fullName;
 formData.email = emailId;
 formData.message = textMessage;
+
+const jsonFormData = JSON.stringify(formData);
+localStorage.setItem("formData", jsonFormData);

--- a/storedata.js
+++ b/storedata.js
@@ -7,3 +7,18 @@ const prefilledData = () => {
     document.getElementById('txt_message').value = formData.message || '';
   }
 };
+
+window.onload = prefilledData();
+
+// Create a single JavaScript object with all the data from the entire form and save it in local storage
+const formInputs = document.querySelectorAll('#form_contact input, #form_contact textarea');
+formInputs.forEach((input) => {
+  input.addEventListener('input', () => {
+    const formData = {
+      name: document.getElementById('txtFullname').value,
+      email: document.getElementById('txtEmail').value,
+      message: document.getElementById('txt_message').value,
+    };
+    localStorage.setItem('formData', JSON.stringify(formData));
+  });
+});

--- a/storedata.js
+++ b/storedata.js
@@ -1,0 +1,5 @@
+// You should implement the following interactions:
+// When the user changes the content of any input field, the data is saved to the local storage.
+// When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.
+// You should use the following data model:
+// You must create a single JavaScript object with all the data from the entire form and save it in local storage. Do not create one local storage entry per input field.

--- a/storedata.js
+++ b/storedata.js
@@ -1,13 +1,9 @@
-// Create form data object
-const formData = {};
-
-const fullName = document.getElementById('txtFullname');
-const emailId = document.getElementById('txtEmail');
-const textMessage = document.getElementById('txt_message');
-
-formData.name = fullName;
-formData.email = emailId;
-formData.message = textMessage;
-
-const jsonFormData = JSON.stringify(formData);
-localStorage.setItem("formData", jsonFormData);
+// Check for pre-filled data to load on form fields.
+const prefilledData = () => {
+  const formData = JSON.parse(localStorage.getItem('formData'));
+  if (formData) {
+    document.getElementById('txtFullname').value = formData.name || '';
+    document.getElementById('txtEmail').value = formData.email || '';
+    document.getElementById('txt_message').value = formData.message || '';
+  }
+};

--- a/storedata.js
+++ b/storedata.js
@@ -10,7 +10,7 @@ const prefilledData = () => {
 
 window.onload = prefilledData();
 
-// Create a single JavaScript object with all the data from the entire form and save it in local storage
+// Create a single JavaScript object with all the data from the entire form
 const formInputs = document.querySelectorAll('#form_contact input, #form_contact textarea');
 formInputs.forEach((input) => {
   input.addEventListener('input', () => {

--- a/storedata.js
+++ b/storedata.js
@@ -1,5 +1,9 @@
-// You should implement the following interactions:
-// When the user changes the content of any input field, the data is saved to the local storage.
-// When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.
-// You should use the following data model:
-// You must create a single JavaScript object with all the data from the entire form and save it in local storage. Do not create one local storage entry per input field.
+const formData = {};
+
+const fullName = document.getElementById('txtFullname');
+const emailId = document.getElementById('txtEmail');
+const textMessage = document.getElementById('txt_message');
+
+formData.name = fullName;
+formData.email = emailId;
+formData.message = textMessage;


### PR DESCRIPTION
**Portfolio: preserve data in the browser**

- When the user changes the content of any input field, the data is saved to the local storage.
- On page load, it checks for data in the local storage 
- If there is data in local storage, the input fields will be pre-filled with this data.
- Created a single JavaScript object with all the data from the entire form and saved it in local storage.

_Student Success has granted me permission to continue this week solo. Proof attached below. If you have any questions please reach out to Marco: success@microverse.org_

![Work-Solo-Week4](https://github.com/rubydevi/my-portfolio/assets/112550568/c3416ba0-401c-4c09-82f2-f9e1e7f62c13)
